### PR TITLE
Use xterm-noapp to fix arrowkeys in vi derivatives and possibly others

### DIFF
--- a/Common/Controllers/SubProcess.swift
+++ b/Common/Controllers/SubProcess.swift
@@ -88,7 +88,7 @@ class SubProcess: NSObject {
 				let bashArgs = ([ "bash", "--login", "-i" ] as NSArray).cStringArray()!
 
 				let env = ([
-					"TERM=xterm-color",
+					"TERM=xterm-noapp",
 					"LANG=en_US.UTF-8",
 					"TERM_PROGRAM=NewTerm",
 					"LC_TERMINAL=NewTerm"

--- a/Common/VT100/VT100Terminal.m
+++ b/Common/VT100/VT100Terminal.m
@@ -1225,7 +1225,7 @@ static VT100Token *decode_string(unsigned char* datap,
 
   _numLock = YES;
 
-  [self setTermType:@"xterm-color"];
+  [self setTermType:@"xterm-noapp"];
 
   _primaryScreen = [[VT100Screen alloc] init];
   _primaryScreen.terminal = self;


### PR DESCRIPTION
Specifically tested by piping `man`'s output through `less` and testing on iOS 13.4.
Info [here](https://invisible-island.net/ncurses/ncurses.faq.html#cursor_appmode) and [here](https://invisible-island.net/xterm/terminfo.html). xterm-noapp is regular xterm with the added feature of the keyboard cursor keys working in things like `vim`. The only feature you'd be losing is the explicit xterm+256color feature, which is redundant on NewTerm.