### PR TITLE
[ci] Only trigger CI on actual code changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,33 +1,41 @@
 name: CI
 
 on:
-  workflow_dispatch:
   push:
+    paths-ignore:
+      - '.gitignore'
+      - '**/.md'
+      - 'assets/**'
   pull_request:
+    paths-ignore:
+      - '.gitignore'
+      - '**/*.md'
+      - 'assets/**'
+  workflow_dispatch:
 
 jobs:
   build:
+    name: Build
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v2
-    - uses: beerpiss/procursus-action@v1
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Procursus
+      uses: beerpiss/procursus-action@v1
       with:
         packages: ldid xz-utils cmark make
         cache: true
         cache-path: ~/__cache
         mirror: 'https://repo.quiprr.dev/procursus/'
-
     - name: Init Theos
       run: git clone --recursive --depth=1 https://github.com/theos/theos.git ~/theos
-
     - name: Compile
       id: package_build
       run: |
         gmake package PACKAGE_VERSION=3.0 THEOS=~/theos
         echo "::set-output name=package::$(cat .theos/last_package)"
-
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2
       with:
-        name: NewTerm 3
+        name: NewTerm3
         path: '${{ steps.package_build.outputs.package }}'


### PR DESCRIPTION
This PR ignores several paths and files which most likely will receive updates, but do not need to trigger the workflow to build the entire project, as these files do not contain any code.

Other changes included in this PR:

- Removed any whitespace between steps
- Added names to jobs and steps: this just looks cleaner
- Renamed uploaded artifact so that its download link doesn't use a `%`